### PR TITLE
Allow building with GHC 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ install: travis/install.sh
 script: travis/script.sh
 matrix:
   include:
+    - env: GHCVER=7.0.4 CABALVER=1.16
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.16, ghc-7.0.4, alex-3.1.4, happy-1.19.5], sources: [hvr-ghc]}}
+    - env: GHCVER=7.2.2 CABALVER=1.16
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.16, ghc-7.2.2, alex-3.1.4, happy-1.19.5], sources: [hvr-ghc]}}
     - env: GHCVER=7.4.2 CABALVER=1.16
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.16, ghc-7.4.2, alex-3.1.4, happy-1.19.5], sources: [hvr-ghc]}}

--- a/th-lift-instances.cabal
+++ b/th-lift-instances.cabal
@@ -29,7 +29,7 @@ library
     exposed-modules:
         Instances.TH.Lift
     build-depends:
-        base >=4.4 && <4.10,
+        base >=4.3 && <4.10,
         template-haskell,
         th-lift <0.8,
         containers >=0.4 && <0.6,


### PR DESCRIPTION
`th-orphans` recently added `th-lift-instances` as a dependency, but since `th-lift-instances` requires `base >= 4.4`, I can't build the [test suite for one of my libraries](https://travis-ci.org/RyanGlScott/text-show-instances/jobs/141886120#L220) on GHC 7.0. Luckily, it appears that `th-lift-instances` builds just fine on GHC 7.0, so this PR lowers the lower version bounds on `base` accordingly.
