### PR TITLE
Support template-haskell 2.17.

### DIFF
--- a/src/Instances/TH/Lift.hs
+++ b/src/Instances/TH/Lift.hs
@@ -130,7 +130,9 @@ import qualified Data.Vector.Unboxed as Vector.Unboxed
 import Control.Applicative (Const (..))
 import Data.Functor.Identity (Identity (..))
 
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_template_haskell(2,17,0)
+#define LIFT_TYPED_DEFAULT liftTyped = Code . unsafeTExpCoerce . lift
+#elif MIN_VERSION_template_haskell(2,16,0)
 #define LIFT_TYPED_DEFAULT liftTyped = unsafeTExpCoerce . lift
 #else
 #define LIFT_TYPED_DEFAULT


### PR DESCRIPTION
The new version of `template-haskell` released with GHC 9 added a `Code` newtype (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3358).  I'm able to build under GHC 9.0.1-alpha1 with this change.