### PR TITLE
bytestring-0.11.2 has lift instances

### DIFF
--- a/src/Instances/TH/Lift.hs
+++ b/src/Instances/TH/Lift.hs
@@ -112,12 +112,14 @@ import qualified Data.Text.Lazy as Text.Lazy
 #endif
 
 -- ByteString
+#if !MIN_VERSION_bytestring(0,11,2)
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Unsafe as ByteString.Unsafe
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import           System.IO.Unsafe (unsafePerformIO)
 #if !MIN_VERSION_template_haskell(2, 8, 0)
 import qualified Data.ByteString.Char8 as ByteString.Char8
+#endif
 #endif
 
 -- Vector
@@ -262,6 +264,7 @@ instance Lift Text.Lazy.Text where
   LIFT_TYPED_DEFAULT
 #endif
 
+#if !MIN_VERSION_bytestring(0,11,2)
 --------------------------------------------------------------------------------
 -- ByteString
 instance Lift ByteString.ByteString where
@@ -285,6 +288,7 @@ instance Lift ByteString.Lazy.ByteString where
     where
       b = ByteString.Lazy.toChunks lb
   LIFT_TYPED_DEFAULT
+#endif
 
 --------------------------------------------------------------------------------
 -- Vector


### PR DESCRIPTION
I also made revisions to previous releases as they failed to compile with duplicate instance error.